### PR TITLE
Enable Windows build for r 4.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,6 +11,9 @@ jobs:
       win_64_r_base3.6:
         CONFIG: win_64_r_base3.6
         UPLOAD_PACKAGES: 'True'
+      win_64_r_base4.0:
+        CONFIG: win_64_r_base4.0
+        UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/win_64_r_base4.0.yaml
+++ b/.ci_support/win_64_r_base4.0.yaml
@@ -1,0 +1,18 @@
+channel_sources:
+- conda-forge,defaults
+channel_targets:
+- conda-forge main
+cran_mirror:
+- https://cran.r-project.org
+m2w64_c_compiler:
+- m2w64-toolchain
+m2w64_cxx_compiler:
+- m2w64-toolchain
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.0'
+target_platform:
+- win-64

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ Current build status
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-prophet-feedstock?branchName=master&jobName=win&configuration=win_64_r_base3.6" alt="variant">
                 </a>
               </td>
+            </tr><tr>
+              <td>win_64_r_base4.0</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2469&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-prophet-feedstock?branchName=master&jobName=win&configuration=win_64_r_base4.0" alt="variant">
+                </a>
+              </td>
             </tr>
           </tbody>
         </table>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,7 @@ source:
 
 build:
   merge_build_host: true  # [win]
-  number: 0
-  skip: true  # [win and r_base == "4.0"]
+  number: 1
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Now that rstan is available for r 4.0 on windows we should be able to build this package for that platform as well.
<!--
Please add any other relevant info below:
-->
